### PR TITLE
TypeError: Cannot read property 'includes' of undefined

### DIFF
--- a/src/GjenbruksElement/Bildeavatar.js
+++ b/src/GjenbruksElement/Bildeavatar.js
@@ -13,8 +13,8 @@ class BildeAvatar extends Component {
   */
   render() {
     const { url } = this.props;
+    if (!url) return null;
     let urlWithNoQueryString =
-      url &&
       "https://data.artsdatabanken.no/" + url.split("?")[0] + "/logo_24.png";
     let classes = "liste_ikon";
     if (urlWithNoQueryString.includes("Biota")) {


### PR DESCRIPTION
Fixes #1637
