### PR TITLE
Bildene øverst på siden sto feilinstillt, er nå satt til cover.

### DIFF
--- a/src/InformasjonsVisning/Katalog/KatalogHeader/KatalogHeaderImage.js
+++ b/src/InformasjonsVisning/Katalog/KatalogHeader/KatalogHeaderImage.js
@@ -32,8 +32,7 @@ const KatalogHeaderImage = ({ meta }) => {
 
   let speciesimg = "https://data.artsdatabanken.no/" + url + "/phylopic_48.png";
 
-  if (url.includes("Biota") && new_url === "no_image") {
-    new_url = "https://data.artsdatabanken.no/" + url + "/foto_408.jpg";
+  if (url.includes("Biota")) {
     backgroundSize = "cover";
   }
 
@@ -58,8 +57,7 @@ const KatalogHeaderImage = ({ meta }) => {
             (new_url !== "no_image" && {
               backgroundSize: backgroundSize,
               backgroundImage: "url(" + new_url + ")",
-              backgroundRepeat: backgroundRepeat,
-              backgroundSize: "cover"
+              backgroundRepeat: backgroundRepeat
             }) || {
               height: 0
             }

--- a/src/InformasjonsVisning/Katalog/KatalogHeader/KatalogHeaderImage.js
+++ b/src/InformasjonsVisning/Katalog/KatalogHeader/KatalogHeaderImage.js
@@ -58,7 +58,8 @@ const KatalogHeaderImage = ({ meta }) => {
             (new_url !== "no_image" && {
               backgroundSize: backgroundSize,
               backgroundImage: "url(" + new_url + ")",
-              backgroundRepeat: backgroundRepeat
+              backgroundRepeat: backgroundRepeat,
+              backgroundSize: "cover"
             }) || {
               height: 0
             }

--- a/src/InformasjonsVisning/Lokalitet/LokalitetElement/Landskapstype.js
+++ b/src/InformasjonsVisning/Lokalitet/LokalitetElement/Landskapstype.js
@@ -17,7 +17,8 @@ const Landskapstype = ({ onNavigate, newlandskap }) => {
           style={{
             backgroundImage: "url(" + newlandskap.bilde.foto.url + ")",
             backgroundRepeat: "no-Repeat",
-            backgroundPosition: "top"
+            backgroundPosition: "top",
+            backgroundSize: "cover"
           }}
           onClick={() => {
             onNavigate(newlandskap.url);

--- a/src/style/InformasjonsSider.scss
+++ b/src/style/InformasjonsSider.scss
@@ -16,6 +16,7 @@
   padding: 0px;
   margin: 5px;
   position: relative;
+  align-self: flex-start;
 }
 
 .subelement_decorative_box {


### PR DESCRIPTION
Når phylopic/artsfoto endret navn, feilet sjekken som stilte dem inn riktig. Nå er den endret så den bør se ok ut.

(eksempel: foto av bjørn før - sentrert og delvis utenfor boksen. nå heldekkende)