### PR TITLE
Hovedmeny åpnes/lukkes vha state, ikke context. Forside styres av path.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -82,120 +82,98 @@ class App extends React.Component {
     const path = this.props.location.pathname;
     console.log("logging,", path);
 
-    if (path === "/") {
-      return (
-        <>
-          <TopBar
-            forside={true}
-            searchFor={this.state.searchFor}
-            onSelectResult={(item) => {
-              let url = item.url;
-              if (item.url[0] !== "/") url = "/" + item.url;
-              history.push(url);
-            }}
-            history={history}
-          />
+    return (
+      <>
+        <TopBar
+          searchFor={this.state.searchFor}
+          onSelectResult={(item) => {
+            let url = item.url;
+            if (item.url[0] !== "/") url = "/" + item.url;
+            history.push(url);
+          }}
+          history={history}
+        />
+        {path === "/" ? (
           <ForsideInformasjon />
-        </>
-      );
-    } else {
-      return (
-        <SettingsContext.Consumer>
-          {(context) => {
-            return (
-              <>
-                <div
-                  className={
-                    this.state.showFullscreen && aktivTab === "kartlag"
-                      ? "hidden_in_fullscreen"
-                      : ""
-                  }
-                >
-                  <TopBar
-                    forside={context.visSplash && path === "/"}
-                    searchFor={this.state.searchFor}
-                    onSelectResult={(item) => {
-                      let url = item.url;
-                      if (item.url[0] !== "/") url = "/" + item.url;
-                      history.push(url);
-                    }}
-                    history={history}
-                  />
-                </div>
-                <>
-                  {false && (
-                    <MobileNavigation
-                      onNavigateToTab={this.handleSetAktivTab}
-                      aktivTab={aktivTab}
-                      hidden_in_fullscreen={this.state.showFullscreen}
-                    />
-                  )}
-                  {false && (
-                    <NinBottomNavigation
-                      aktivTab={aktivTab}
-                      onNavigateToTab={this.handleSetAktivTab}
-                    />
-                  )}
+        ) : (
+          <>
+            <b>{path}</b>
+            {false && (
+              <MobileNavigation
+                onNavigateToTab={this.handleSetAktivTab}
+                aktivTab={aktivTab}
+                hidden_in_fullscreen={this.state.showFullscreen}
+              />
+            )}
+            {false && (
+              <NinBottomNavigation
+                aktivTab={aktivTab}
+                onNavigateToTab={this.handleSetAktivTab}
+              />
+            )}
 
-                  {aktivTab === "kartlaginnstillinger" && (
-                    <Kartlaginnstillinger
-                      meta={this.state.meta}
-                      onUpdateLayerProp={this.handleUpdateLayerProp}
-                      onNavigateToTab={this.handleSetAktivTab}
-                      onClose={this.handleClosePunkt}
-                    />
-                  )}
-                  {aktivTab === "punkt" && (
-                    <Punkt
-                      punkt={this.state.punkt}
-                      aktivTab={aktivTab}
-                      onNavigateToTab={this.handleSetAktivTab}
-                      onNavigate={this.handleNavigate}
-                      onClose={this.handleClosePunkt}
-                    />
-                  )}
-                  {aktivTab === "kartlegging" && (
-                    <Kartlegging
-                      punkt={this.state.punkt}
-                      onNavigate={this.handleNavigate}
-                      onNavigateToTab={this.handleSetAktivTab}
-                      onClose={this.handleClosePunkt}
-                    />
-                  )}
+            {aktivTab === "kartlaginnstillinger" && (
+              <Kartlaginnstillinger
+                meta={this.state.meta}
+                onUpdateLayerProp={this.handleUpdateLayerProp}
+                onNavigateToTab={this.handleSetAktivTab}
+                onClose={this.handleClosePunkt}
+              />
+            )}
+            {aktivTab === "punkt" && (
+              <Punkt
+                punkt={this.state.punkt}
+                aktivTab={aktivTab}
+                onNavigateToTab={this.handleSetAktivTab}
+                onNavigate={this.handleNavigate}
+                onClose={this.handleClosePunkt}
+              />
+            )}
+            {aktivTab === "kartlegging" && (
+              <Kartlegging
+                punkt={this.state.punkt}
+                onNavigate={this.handleNavigate}
+                onNavigateToTab={this.handleSetAktivTab}
+                onClose={this.handleClosePunkt}
+              />
+            )}
 
-                  {aktivTab === "hjelp" && <Hjelp aktivTab={aktivTab} />}
+            {aktivTab === "hjelp" && <Hjelp aktivTab={aktivTab} />}
 
-                  {aktivTab === "informasjon" && (
-                    <InformasjonsVisning
-                      onNavigate={this.handleNavigate}
-                      path={path}
-                      aktivTab={aktivTab}
-                      show_current={this.state.showCurrent}
-                      handleShowCurrent={this.handleShowCurrent}
-                      aktiveLag={this.state.aktiveLag}
-                      mapBounds={this.state.actualBounds}
-                      onMouseEnter={this.handleMouseEnter}
-                      onMouseLeave={this.handleMouseLeave}
-                      onFitBounds={this.handleFitBounds}
-                      erAktivert={erAktivert}
-                      opplyst={this.state.opplyst}
-                      onToggleLayer={() => {
-                        this.handleToggleLayer();
-                        if (!context.visAktiveLag) context.onToggleAktiveLag();
-                      }}
-                      meta={this.state.meta}
-                      searchFor={this.state.searchFor}
-                      onClearSearchFor={this.handleClearSearchFor}
-                      onUpdateLayerProp={this.handleUpdateLayerProp}
-                      onUpdateMetaProp={this.handleUpdateMetaProp}
-                      visAktiveLag={context.visAktiveLag}
-                      onToggleAktiveLag={context.onToggleAktiveLag}
-                      onNavigateToTab={this.handleSetAktivTab}
-                      onClose={this.handleClosePunkt}
-                    />
-                  )}
-
-                  {!(context.visSplash && path === "/") && (
+            <SettingsContext.Consumer>
+              {(context) => {
+                return (
+                  <>
+                    {aktivTab === "informasjon" && (
+                      <InformasjonsVisning
+                        onNavigate={this.handleNavigate}
+                        path={path}
+                        aktivTab={aktivTab}
+                        show_current={this.state.showCurrent}
+                        handleShowCurrent={this.handleShowCurrent}
+                        aktiveLag={this.state.aktiveLag}
+                        mapBounds={this.state.actualBounds}
+                        onMouseEnter={this.handleMouseEnter}
+                        onMouseLeave={this.handleMouseLeave}
+                        onFitBounds={this.handleFitBounds}
+                        erAktivert={erAktivert}
+                        opplyst={this.state.opplyst}
+                        onToggleLayer={() => {
+                          this.handleToggleLayer();
+                          if (!context.visAktiveLag)
+                            context.onToggleAktiveLag();
+                        }}
+                        meta={this.state.meta}
+                        searchFor={this.state.searchFor}
+                        onClearSearchFor={this.handleClearSearchFor}
+                        onUpdateLayerProp={this.handleUpdateLayerProp}
+                        onUpdateMetaProp={this.handleUpdateMetaProp}
+                        visAktiveLag={context.visAktiveLag}
+                        onToggleAktiveLag={context.onToggleAktiveLag}
+                        onNavigateToTab={this.handleSetAktivTab}
+                        onClose={this.handleClosePunkt}
+                      />
+                    )}
                     <Kartlag
                       aktivTab={aktivTab}
                       lokalitetdata={this.state.lokalitetdata}
@@ -233,46 +211,43 @@ class App extends React.Component {
                         onMouseLeave={this.handleMouseLeave}
                       />
                     </Kartlag>
-                  )}
+                    <Kart
+                      markerCoordinates={this.state.markerCoordinates}
+                      onMarkerClick={this.handleMarkerClick}
+                      lokalitetdata={this.state.lokalitetdata}
+                      path={this.props.location.search}
+                      aktivTab={aktivTab}
+                      show_current={this.state.showCurrent}
+                      bounds={this.state.fitBounds}
+                      latitude={65.4}
+                      longitude={10.77}
+                      zoom={3}
+                      aktiveLag={this.state.aktiveLag}
+                      opplyst={this.state.opplystKode}
+                      meta={this.state.meta}
+                      onMapMove={context.onMapMove}
+                      history={history}
+                      onRemoveSelectedLayer={this.handleRemoveSelectedLayer}
+                      onMouseEnter={this.handleMouseEnter}
+                      onMouseLeave={this.handleMouseLeave}
+                      showFullscreen={
+                        this.state.showFullscreen && aktivTab === "kartlag"
+                      }
+                      handleFullscreen={this.handleFullscreen}
+                    />
+                  </>
+                );
+              }}
+            </SettingsContext.Consumer>
 
-                  <Kart
-                    markerCoordinates={this.state.markerCoordinates}
-                    onMarkerClick={this.handleMarkerClick}
-                    lokalitetdata={this.state.lokalitetdata}
-                    path={this.props.location.search}
-                    aktivTab={aktivTab}
-                    show_current={this.state.showCurrent}
-                    bounds={this.state.fitBounds}
-                    latitude={65.4}
-                    longitude={10.77}
-                    zoom={3}
-                    aktiveLag={this.state.aktiveLag}
-                    opplyst={this.state.opplystKode}
-                    meta={this.state.meta}
-                    onMapMove={context.onMapMove}
-                    history={history}
-                    onRemoveSelectedLayer={this.handleRemoveSelectedLayer}
-                    onMouseEnter={this.handleMouseEnter}
-                    onMouseLeave={this.handleMouseLeave}
-                    showFullscreen={
-                      this.state.showFullscreen && aktivTab === "kartlag"
-                    }
-                    handleFullscreen={this.handleFullscreen}
-                  />
-                </>
-
-                {true && (
-                  <HamburgerMeny
-                    spraak={this.state.spraak}
-                    handleSpraak={this.handleSpraak}
-                  />
-                )}
-              </>
-            );
-          }}
-        </SettingsContext.Consumer>
-      );
-    }
+            <HamburgerMeny
+              spraak={this.state.spraak}
+              handleSpraak={this.handleSpraak}
+            />
+          </>
+        )}
+      </>
+    );
   }
 
   handleMarkerClick = (coords) => {

--- a/src/App.js
+++ b/src/App.js
@@ -68,6 +68,7 @@ class App extends React.Component {
       showCurrent: true,
       showFullscreen: false,
       spraak: "nb",
+      showHovedmeny: false,
     };
     exportableSpraak = this;
     exportableFullscreen = this;
@@ -86,6 +87,7 @@ class App extends React.Component {
       <>
         <TopBar
           searchFor={this.state.searchFor}
+          handleHovedMeny={this.handleHovedMeny}
           onSelectResult={(item) => {
             let url = item.url;
             if (item.url[0] !== "/") url = "/" + item.url;
@@ -243,6 +245,8 @@ class App extends React.Component {
             <HamburgerMeny
               spraak={this.state.spraak}
               handleSpraak={this.handleSpraak}
+              open={this.state.showHovedmeny}
+              handleHovedMeny={this.handleHovedMeny}
             />
           </>
         )}
@@ -283,6 +287,10 @@ class App extends React.Component {
   };
   handleSpraak = (spraak) => {
     this.setState({ spraak: spraak });
+  };
+
+  handleHovedMeny = () => {
+    this.setState({ showHovedmeny: !this.state.showHovedmeny });
   };
 
   handleFullscreen = (showFullscreen) => {

--- a/src/App.js
+++ b/src/App.js
@@ -80,11 +80,29 @@ class App extends React.Component {
     if (this.state.meta)
       erAktivert = !!this.state.aktiveLag[this.state.meta.kode];
     const path = this.props.location.pathname;
-    return (
-      <SettingsContext.Consumer>
-        {(context) => {
-          return (
-            <>
+    console.log("logging,", path);
+
+    if (path === "/") {
+      return (
+        <>
+          <TopBar
+            forside={true}
+            searchFor={this.state.searchFor}
+            onSelectResult={(item) => {
+              let url = item.url;
+              if (item.url[0] !== "/") url = "/" + item.url;
+              history.push(url);
+            }}
+            history={history}
+          />
+          <ForsideInformasjon />
+        </>
+      );
+    } else {
+      return (
+        <SettingsContext.Consumer>
+          {(context) => {
+            return (
               <>
                 <div
                   className={
@@ -104,9 +122,6 @@ class App extends React.Component {
                     history={history}
                   />
                 </div>
-
-                {context.visSplash && path === "/" && <ForsideInformasjon />}
-
                 <>
                   {false && (
                     <MobileNavigation
@@ -210,7 +225,8 @@ class App extends React.Component {
                         onUpdateMetaProp={this.handleUpdateMetaProp}
                         onToggleLayer={() => {
                           this.handleToggleLayer();
-                          if (!context.visAktiveLag) context.onToggleAktiveLag();
+                          if (!context.visAktiveLag)
+                            context.onToggleAktiveLag();
                         }}
                         opplyst={this.state.opplyst}
                         onMouseEnter={this.handleMouseEnter}
@@ -252,11 +268,11 @@ class App extends React.Component {
                   />
                 )}
               </>
-            </>
-          );
-        }}
-      </SettingsContext.Consumer>
-    );
+            );
+          }}
+        </SettingsContext.Consumer>
+      );
+    }
   }
 
   handleMarkerClick = (coords) => {
@@ -356,19 +372,27 @@ class App extends React.Component {
   async downloadMeta(url) {
     const meta = await backend.hentKodeMeta(url);
     metaSjekk(meta, this);
-    if (meta.bbox && meta.kart && meta.kart.aktivtFormat && meta.kart.format[meta.kart.aktivtFormat].filnavn) {
+    if (
+      meta.bbox &&
+      meta.kart &&
+      meta.kart.aktivtFormat &&
+      meta.kart.format[meta.kart.aktivtFormat].filnavn
+    ) {
       let filnavn = meta.kart.format[meta.kart.aktivtFormat].filnavn;
       let tilejsonUrl = meta.kart.format[meta.kart.aktivtFormat].url;
       if (tilejsonUrl && tilejsonUrl.indexOf(url) < 0) {
         // find correct path
         do {
           url = url.substr(0, url.lastIndexOf("/"));
-        } while (url.length > 0 && tilejsonUrl.indexOf(url) < 0)
+        } while (url.length > 0 && tilejsonUrl.indexOf(url) < 0);
       }
       const tilejson = await backend.hentKodeTilejson(url, filnavn);
       if (tilejson && tilejson.bounds && tilejson.bounds.length > 3) {
         // console.log('bbox før', meta.bbox);
-        meta.bbox = [[tilejson.bounds[1], tilejson.bounds[0]], [tilejson.bounds[3], tilejson.bounds[2]]];
+        meta.bbox = [
+          [tilejson.bounds[1], tilejson.bounds[0]],
+          [tilejson.bounds[3], tilejson.bounds[2]],
+        ];
         // console.log('bbox etter', meta.bbox);
       }
     }

--- a/src/HamburgerMeny/HamburgerMeny.js
+++ b/src/HamburgerMeny/HamburgerMeny.js
@@ -29,6 +29,7 @@ import config from "../Funksjoner/config";
 class HamburgerMeny extends Component {
   render() {
     let spraak = this.props.spraak;
+    console.log("building. ", this.props.open);
     const handleSpraak = this.props.handleSpraak;
     return (
       <SettingsContext.Consumer>
@@ -36,9 +37,9 @@ class HamburgerMeny extends Component {
           <SwipeableDrawer
             className="hamburger_sidebar"
             anchor="left"
-            onClose={context.onToggleHovedmeny}
-            onOpen={context.onToggleHovedmeny}
-            open={context.visHovedmeny}
+            onClose={this.props.handleHovedMeny}
+            onOpen={this.props.handleHovedMeny}
+            open={this.props.open}
           >
             <List className="hamburger_sidebar">
               <ListItem>
@@ -53,7 +54,7 @@ class HamburgerMeny extends Component {
                   }
                 />
                 <ListItemSecondaryAction>
-                  <IconButton onClick={context.onToggleHovedmeny}>
+                  <IconButton onClick={this.props.handleHovedMeny}>
                     <NavigationChevronLeftDouble />
                   </IconButton>
                 </ListItemSecondaryAction>
@@ -79,7 +80,7 @@ class HamburgerMeny extends Component {
                   primary="Last ned data"
                   onClick={() => {
                     this.handleWindowOpen("https://data.artsdatabanken.no/");
-                    context.onToggleHovedmeny();
+                    this.props.handleHovedMeny();
                   }}
                 />
                 <Menyelement
@@ -87,7 +88,7 @@ class HamburgerMeny extends Component {
                     this.handleWindowOpen(
                       "https://github.com/Artsdatabanken/nin-kart-frontend/wiki/%C3%98nsker-du-%C3%A5-bidra-med-data%3F"
                     );
-                    context.onToggleHovedmeny();
+                    this.props.handleHovedMeny();
                   }}
                   icon={<CloudUpload />}
                   primary="Levere data"
@@ -96,7 +97,7 @@ class HamburgerMeny extends Component {
                 <Menyelement
                   onClick={() => {
                     this.handleClick("/Datakilde/");
-                    context.onToggleHovedmeny();
+                    this.props.handleHovedMeny();
                   }}
                   icon={<AssignmentInd />}
                   primary="Datakilder"
@@ -106,7 +107,7 @@ class HamburgerMeny extends Component {
                     this.handleWindowOpen(
                       "https://github.com/Artsdatabanken/nin-kart-frontend"
                     );
-                    context.onToggleHovedmeny();
+                    this.props.handleHovedMeny();
                   }}
                   icon={<GitHub />}
                   primary="Kildekode"
@@ -117,7 +118,7 @@ class HamburgerMeny extends Component {
                   primary="Hjelp"
                   onClick={() => {
                     this.handleClick("?hjelp");
-                    context.onToggleHovedmeny();
+                    this.props.handleHovedMeny();
                   }}
                 />
                 <button
@@ -126,7 +127,7 @@ class HamburgerMeny extends Component {
                     this.handleWindowOpen(
                       "https://github.com/Artsdatabanken/nin-kart-frontend/issues"
                     );
-                    context.onToggleHovedmeny();
+                    this.props.handleHovedMeny();
                   }}
                 >
                   <Comment /> <span>Tilbakemeldinger</span> <OpenInNew />
@@ -135,7 +136,7 @@ class HamburgerMeny extends Component {
                 <Menyelement
                   onClick={() => {
                     this.handleWindowOpen("https://artsdatabanken.no");
-                    context.onToggleHovedmeny();
+                    this.props.handleHovedMeny();
                   }}
                   icon={
                     <img

--- a/src/HamburgerMeny/HamburgerMeny.js
+++ b/src/HamburgerMeny/HamburgerMeny.js
@@ -29,7 +29,6 @@ import config from "../Funksjoner/config";
 class HamburgerMeny extends Component {
   render() {
     let spraak = this.props.spraak;
-    console.log("building. ", this.props.open);
     const handleSpraak = this.props.handleSpraak;
     return (
       <SettingsContext.Consumer>

--- a/src/HamburgerMeny/Utforsk/Utforsk.js
+++ b/src/HamburgerMeny/Utforsk/Utforsk.js
@@ -11,18 +11,12 @@ const Utforsk = ({ parent, context }) => {
   if (!parent.history) {
     the_props = parent.props;
   }
-  function onToggleHovedmeny() {
-    if (context) {
-      context.onToggleHovedmeny();
-    }
-  }
 
   return (
     <>
       <Menyelement
         onClick={(e) => {
           the_props.history.push("/Natur_i_Norge/Natursystem");
-          onToggleHovedmeny();
         }}
         icon={
           <img
@@ -37,7 +31,6 @@ const Utforsk = ({ parent, context }) => {
       <Menyelement
         onClick={(e) => {
           the_props.history.push("/Natur_i_Norge/Landskap");
-          onToggleHovedmeny();
         }}
         icon={<Landscape />}
         primary="Landskap"
@@ -45,8 +38,7 @@ const Utforsk = ({ parent, context }) => {
 
       <Menyelement
         onClick={(e) => {
-          the_props.history.push("/Administrativ_grense/");
-          onToggleHovedmeny();
+          the_props.history.push("/Administrativ_grense");
         }}
         icon={
           <img
@@ -61,7 +53,6 @@ const Utforsk = ({ parent, context }) => {
       <Menyelement
         onClick={(e) => {
           the_props.history.push("/Naturvernområde/");
-          onToggleHovedmeny();
         }}
         icon={<Naturvern />}
         primary="Naturvernområder"
@@ -71,7 +62,6 @@ const Utforsk = ({ parent, context }) => {
         <Menyelement
           onClick={(e) => {
             the_props.history.push("/Biota/");
-            onToggleHovedmeny();
           }}
           icon={<Pets />}
           primary="Arter"

--- a/src/HamburgerMeny/Utforsk/Utforsk.js
+++ b/src/HamburgerMeny/Utforsk/Utforsk.js
@@ -17,6 +17,7 @@ const Utforsk = ({ parent, context }) => {
       <Menyelement
         onClick={(e) => {
           the_props.history.push("/Natur_i_Norge/Natursystem");
+          the_props.handleHovedMeny();
         }}
         icon={
           <img
@@ -31,6 +32,7 @@ const Utforsk = ({ parent, context }) => {
       <Menyelement
         onClick={(e) => {
           the_props.history.push("/Natur_i_Norge/Landskap");
+          the_props.handleHovedMeny();
         }}
         icon={<Landscape />}
         primary="Landskap"
@@ -39,6 +41,7 @@ const Utforsk = ({ parent, context }) => {
       <Menyelement
         onClick={(e) => {
           the_props.history.push("/Administrativ_grense");
+          the_props.handleHovedMeny();
         }}
         icon={
           <img
@@ -53,6 +56,7 @@ const Utforsk = ({ parent, context }) => {
       <Menyelement
         onClick={(e) => {
           the_props.history.push("/Naturvernområde/");
+          the_props.handleHovedMeny();
         }}
         icon={<Naturvern />}
         primary="Naturvernområder"
@@ -62,6 +66,7 @@ const Utforsk = ({ parent, context }) => {
         <Menyelement
           onClick={(e) => {
             the_props.history.push("/Biota/");
+            the_props.handleHovedMeny();
           }}
           icon={<Pets />}
           primary="Arter"

--- a/src/Kart/LeafletTangram/scene/scene.js
+++ b/src/Kart/LeafletTangram/scene/scene.js
@@ -22,20 +22,26 @@ function createScene(props) {
 }
 
 function updateScene(config, props) {
-  let lokalitetdata = props.lokalitetdata || null;
-  let bakgrunn = props.aktiveLag.bakgrunnskart;
-  bakgrunn = bakgrunn.kart.format[bakgrunn.kart.aktivtFormat];
-  config.scene.background.color = bakgrunn.land_farge || "#f2f2f2";
-  config.layers = {};
-  const viserKatalog = !!props.meta; // meta = true or meta = false , never meta = null
-  lagNåværendeLag(config, props);
-  if (lokalitetdata !== null) {
-    lagAktiveLag(lokalitetdata, true, props.opplyst, config);
+  if (config) {
+    let lokalitetdata = props.lokalitetdata || null;
+    let bakgrunn = props.aktiveLag.bakgrunnskart;
+    bakgrunn = bakgrunn.kart.format[bakgrunn.kart.aktivtFormat];
+    config.scene.background.color = bakgrunn.land_farge || "#f2f2f2";
+    config.layers = {};
+    const viserKatalog = !!props.meta; // meta = true or meta = false , never meta = null
+    lagNåværendeLag(config, props);
+    if (lokalitetdata !== null) {
+      lagAktiveLag(lokalitetdata, true, props.opplyst, config);
+    }
+    lagAktiveLag(props.aktiveLag, viserKatalog, props.opplyst, config);
+    lagTemp(config);
+    //  console.log(config);
+    return config;
+  } else {
+    console.error("could not find config. Trying again");
+    //createScene(props);
+    return null;
   }
-  lagAktiveLag(props.aktiveLag, viserKatalog, props.opplyst, config);
-  lagTemp(config);
-  //  console.log(config);
-  return config;
 }
 
 export { createScene, updateScene };

--- a/src/SettingsContainer.js
+++ b/src/SettingsContainer.js
@@ -31,7 +31,6 @@ class SettingsContainer extends Component {
           width: this.state.width,
           onUpdateValue: this.handleUpdateValue,
           onToggleAktiveLag: this.handleToggleAktivelag,
-          onToggleHovedmeny: this.handleToggleHovedmeny,
           onToggleForside: this.handleToggleForside,
           onMapMove: this.handleMapMove,
           onSetWidth: this.setWidth,
@@ -50,10 +49,6 @@ class SettingsContainer extends Component {
 
   handleToggleAktivelag = () =>
     this.handleUpdateValue("visAktiveLag", !this.state.visAktiveLag);
-
-  handleToggleHovedmeny = () => {
-    this.handleUpdateValue("visHovedmeny", !this.state.visHovedmeny);
-  };
 
   setWidth = (width) => {
     this.setState({ width });

--- a/src/TopBar/TopBar.js
+++ b/src/TopBar/TopBar.js
@@ -6,7 +6,7 @@ import { SettingsContext } from "../SettingsContext";
 import Hamburger from "@material-ui/icons/Menu";
 import backend from "../Funksjoner/backend";
 
-const TopBar = ({ onSelectResult, searchFor, forside, history }) => {
+const TopBar = ({ onSelectResult, searchFor, history }) => {
   const [hits, setHits] = useState([]);
   const [query, setQuery] = useState(null);
   const latestQuery = useRef();
@@ -26,7 +26,7 @@ const TopBar = ({ onSelectResult, searchFor, forside, history }) => {
   return (
     <SettingsContext.Consumer>
       {(context) => (
-        <div className={!forside ? "top_bar" : "top_bar forside_topbar"}>
+        <div className={"top_bar"}>
           <button
             className="invisible_icon_button hamburger"
             onKeyDown={(e) => {
@@ -38,23 +38,22 @@ const TopBar = ({ onSelectResult, searchFor, forside, history }) => {
           >
             <Hamburger />
           </button>
-          {!forside && (
-            <div
-              className="header_text"
-              onClick={() => {
-                history.push("/");
-              }}
-            >
-              <span style={{ fontWeight: 500 }}>NiN-kart</span>
-              {false && (
-                <img
-                  src="/logoer/small_icon_two.png"
-                  className="logo_image"
-                  alt="artsdatabanken logo"
-                />
-              )}
-            </div>
-          )}
+
+          <div
+            className="header_text"
+            onClick={() => {
+              history.push("/");
+            }}
+          >
+            <span style={{ fontWeight: 500 }}>NiN-kart</span>
+            {false && (
+              <img
+                src="/logoer/small_icon_two.png"
+                className="logo_image"
+                alt="artsdatabanken logo"
+              />
+            )}
+          </div>
 
           <div className="search_elements_container">
             <Searchbar

--- a/src/TopBar/TopBar.js
+++ b/src/TopBar/TopBar.js
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from "react";
 import ResultatListe from "./ResultatListe";
 import Searchbar from "./Searchbar/Searchbar";
 import "./../style/TopBar.scss";
-import { SettingsContext } from "../SettingsContext";
 import Hamburger from "@material-ui/icons/Menu";
 import backend from "../Funksjoner/backend";
 
@@ -45,7 +44,7 @@ const TopBar = ({ onSelectResult, searchFor, history, handleHovedMeny }) => {
           history.push("/");
         }}
       >
-        <span style={{ fontWeight: 500 }}>NiN-kart</span>
+        <span style={{ fontWeight: 500 }}>NiN-kart | - 10:40</span>
         {false && (
           <img
             src="/logoer/small_icon_two.png"

--- a/src/TopBar/TopBar.js
+++ b/src/TopBar/TopBar.js
@@ -6,7 +6,7 @@ import { SettingsContext } from "../SettingsContext";
 import Hamburger from "@material-ui/icons/Menu";
 import backend from "../Funksjoner/backend";
 
-const TopBar = ({ onSelectResult, searchFor, history }) => {
+const TopBar = ({ onSelectResult, searchFor, history, handleHovedMeny }) => {
   const [hits, setHits] = useState([]);
   const [query, setQuery] = useState(null);
   const latestQuery = useRef();
@@ -24,57 +24,55 @@ const TopBar = ({ onSelectResult, searchFor, history }) => {
     fetchData();
   }, [query]);
   return (
-    <SettingsContext.Consumer>
-      {(context) => (
-        <div className={"top_bar"}>
-          <button
-            className="invisible_icon_button hamburger"
-            onKeyDown={(e) => {
-              if (e.keyCode === 13) {
-                context.onToggleHovedmeny();
-              }
-            }}
-            onClick={context.onToggleHovedmeny}
-          >
-            <Hamburger />
-          </button>
+    <div className={"top_bar"}>
+      <button
+        className="invisible_icon_button hamburger"
+        onKeyDown={(e) => {
+          if (e.keyCode === 13) {
+            handleHovedMeny();
+          }
+        }}
+        onClick={(e) => {
+          handleHovedMeny();
+        }}
+      >
+        <Hamburger />
+      </button>
 
-          <div
-            className="header_text"
-            onClick={() => {
-              history.push("/");
-            }}
-          >
-            <span style={{ fontWeight: 500 }}>NiN-kart</span>
-            {false && (
-              <img
-                src="/logoer/small_icon_two.png"
-                className="logo_image"
-                alt="artsdatabanken logo"
-              />
-            )}
-          </div>
+      <div
+        className="header_text"
+        onClick={() => {
+          history.push("/");
+        }}
+      >
+        <span style={{ fontWeight: 500 }}>NiN-kart</span>
+        {false && (
+          <img
+            src="/logoer/small_icon_two.png"
+            className="logo_image"
+            alt="artsdatabanken logo"
+          />
+        )}
+      </div>
 
-          <div className="search_elements_container">
-            <Searchbar
-              query={query}
-              setHits={setHits}
-              onQueryChange={setQuery}
-              hits={hits}
-            />
+      <div className="search_elements_container">
+        <Searchbar
+          query={query}
+          setHits={setHits}
+          onQueryChange={setQuery}
+          hits={hits}
+        />
 
-            <ResultatListe
-              query={query}
-              searchResults={hits}
-              onSelect={(item) => {
-                setQuery(null);
-                onSelectResult(item);
-              }}
-            />
-          </div>
-        </div>
-      )}
-    </SettingsContext.Consumer>
+        <ResultatListe
+          query={query}
+          searchResults={hits}
+          onSelect={(item) => {
+            setQuery(null);
+            onSelectResult(item);
+          }}
+        />
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
- Hovedmeny benyttet context, ikke state. Dette er uheldig adferd, da det i dette tilfellet er riktig å benytte state. Man skal ikke huske om menyen er åpen eller ikke senere. 
- Forsiden bruker ikke lenger visSplash context variabel for å tidvis vises på forsiden. Er man på url "/" får man forsiden. Er man ikke, får man kartsiden. 

fixes #1744
