### PR TITLE
osm_light bakgrunnsinnstilingers fargevelgere

### DIFF
--- a/src/Kart/LeafletTangram/Leaflet.js
+++ b/src/Kart/LeafletTangram/Leaflet.js
@@ -33,7 +33,8 @@ class LeafletTangram extends React.Component {
     const options = {
       zoomControl: false,
       inertia: true,
-      minZoom: 3
+      minZoom: 3,
+      doubleClickZoom: false
     };
 
     let map = L.map(this.mapEl, options);

--- a/src/Kartlag/AktiveKartlag/EkspandertMeny/FellesElementer/FargeVelger.js
+++ b/src/Kartlag/AktiveKartlag/EkspandertMeny/FellesElementer/FargeVelger.js
@@ -4,20 +4,24 @@ import ColorPicker from "../../../../GjenbruksElement/ColorPicker";
 import { ListSubheader } from "@material-ui/core";
 class FargeVelger extends Component {
   render() {
-    const { onUpdateLayerProp, where, color, elementType } = this.props;
+    const { onUpdateLayerProp, where, color, elementType, title } = this.props;
     let what = "farge";
     if (this.props.what) {
       what = this.props.what;
     }
+    let selector_title = "Farge";
+    if (title) {
+      selector_title = title;
+    }
 
     return (
-      <div className="kartlag_submenu">
-        <ListSubheader>Farge</ListSubheader>
+      <div className="">
+        <ListSubheader>{selector_title}</ListSubheader>
         <ColorPicker
           tabIndex="1"
           color={color}
           alpha
-          onChange={(farge) => {
+          onChange={farge => {
             const rgbString = tinycolor(farge.rgb).toRgbString();
             if (elementType) {
               onUpdateLayerProp(where, what, rgbString, "barn");

--- a/src/Kartlag/AktiveKartlag/EkspandertMeny/Visualisering/BgInnstillinger/BakgrunnInnstillingListeElement.js
+++ b/src/Kartlag/AktiveKartlag/EkspandertMeny/Visualisering/BgInnstillinger/BakgrunnInnstillingListeElement.js
@@ -1,8 +1,8 @@
 import { Switch } from "@material-ui/core";
 import React, { useState } from "react";
-import VelgFargeBoks from "../../FellesElementer/VelgFargeBoks";
 import FargeVelger from "../../FellesElementer/FargeVelger";
 import SliderElement from "../../../../../GjenbruksElement/SliderElement";
+import { FormatColorFill, Close } from "@material-ui/icons";
 
 const BakgrunnInnstillingListeElement = ({
   onUpdateLayerProp,
@@ -11,14 +11,14 @@ const BakgrunnInnstillingListeElement = ({
   erSynlig,
   farge,
   omriss,
-  stroke,
+  stroke
 }) => {
   const [showColours, setShowColours] = useState(false);
 
   return (
     <div>
       <Switch
-        onClick={(e) => e.stopPropagation()}
+        onClick={e => e.stopPropagation()}
         onChange={() => {
           onUpdateLayerProp("bakgrunnskart", oppdaterElement, !erSynlig);
         }}
@@ -30,46 +30,84 @@ const BakgrunnInnstillingListeElement = ({
       {erSynlig && (
         <>
           <span
-            onClick={(e) => {
+            onClick={e => {
               // console.log("farge: ", farge);
               setShowColours(!showColours);
             }}
           >
             {farge}
-            <VelgFargeBoks farge={farge} />
+
+            <button
+              className="kartlag_element_buttons"
+              style={{ float: "right", position: "relative" }}
+              onClick={() => {
+                setShowColours(!showColours);
+              }}
+            >
+              <FormatColorFill />
+              <div
+                style={{
+                  width: "100%",
+                  background: farge,
+                  height: "8px",
+                  position: "absolute",
+                  right: 0,
+                  bottom: 0,
+                  border: "1px solid grey"
+                }}
+              />
+            </button>
           </span>
           {showColours && (
-            <FargeVelger
-              color={farge}
-              onUpdateLayerProp={onUpdateLayerProp}
-              where={"bakgrunnskart"}
-              what={oppdaterElement + "_farge"}
-            />
-          )}
-          {showColours && omriss !== undefined && (
-            <FargeVelger
-              color={omriss}
-              onUpdateLayerProp={onUpdateLayerProp}
-              where={"bakgrunnskart"}
-              what={oppdaterElement + "_stroke_farge"}
-              title={"Velg farge på omriss"}
-            />
-          )}
-          {showColours && stroke !== undefined && (
-            <SliderElement
-              value={stroke || 0}
-              min={0}
-              max={10}
-              step={0.2}
-              tittel={"Tykkelse: " + (stroke || 0).toFixed(1) + " piksler"}
-              onChange={(v) =>
-                onUpdateLayerProp(
-                  "bakgrunnskart",
-                  oppdaterElement + "_stroke_width",
-                  v
-                )
-              }
-            />
+            <div
+              className="subsection"
+              style={{ background: "white", position: "relative" }}
+            >
+              <button
+                onClick={() => {
+                  setShowColours(!showColours);
+                }}
+                className="closebutton"
+              >
+                <Close />
+              </button>
+
+              <h6>Velg farger </h6>
+
+              <FargeVelger
+                color={farge}
+                onUpdateLayerProp={onUpdateLayerProp}
+                where={"bakgrunnskart"}
+                what={oppdaterElement + "_farge"}
+                title={"Farge på elementet"}
+              />
+
+              {omriss !== undefined && (
+                <FargeVelger
+                  color={omriss}
+                  onUpdateLayerProp={onUpdateLayerProp}
+                  where={"bakgrunnskart"}
+                  what={oppdaterElement + "_stroke_farge"}
+                  title={"Farge på omriss"}
+                />
+              )}
+              {stroke !== undefined && (
+                <SliderElement
+                  value={stroke || 0}
+                  min={0}
+                  max={10}
+                  step={0.2}
+                  tittel={"Tykkelse: " + (stroke || 0).toFixed(1) + " piksler"}
+                  onChange={v =>
+                    onUpdateLayerProp(
+                      "bakgrunnskart",
+                      oppdaterElement + "_stroke_width",
+                      v
+                    )
+                  }
+                />
+              )}
+            </div>
           )}
         </>
       )}

--- a/src/Kartlag/AktiveKartlag/EkspandertMeny/Visualisering/BgInnstillinger/BakgrunnInnstillinger.js
+++ b/src/Kartlag/AktiveKartlag/EkspandertMeny/Visualisering/BgInnstillinger/BakgrunnInnstillinger.js
@@ -11,11 +11,11 @@ class BakgrunnInnstillinger extends Component {
     const current = aktivtFormat.aktivtFormat;
     const kf = aktivtFormat.format[current];
     const what = "kart.format." + current;
-    // console.log(kf);
+    console.log(kf.vann_farge);
 
     return (
       <List>
-        {/* 
+        {/*
         {false && (
           <div className="sidebar_element">
             <Terreng
@@ -27,8 +27,8 @@ class BakgrunnInnstillinger extends Component {
         )}
         */}
 
-        <div className="sidebar_element">
-          <h3>Områder</h3>
+        <div className="subsection">
+          <h5>Områder</h5>
 
           <BakgrunnInnstillingListeElement
             onUpdateLayerProp={onUpdateLayerProp}
@@ -55,8 +55,8 @@ class BakgrunnInnstillinger extends Component {
           />
         </div>
 
-        <div className="sidebar_element">
-          <h3>Administrative grenser</h3>
+        <div className="subsection">
+          <h5>Administrative grenser</h5>
           <BakgrunnInnstillingListeElement
             onUpdateLayerProp={onUpdateLayerProp}
             oppdaterElement={what + ".landegrense"}
@@ -80,8 +80,8 @@ class BakgrunnInnstillinger extends Component {
           />
         </div>
 
-        <div className="sidebar_element">
-          <h3>Etiketter</h3>
+        <div className="subsection">
+          <h5>Etiketter</h5>
           <BakgrunnInnstillingListeElement
             onUpdateLayerProp={onUpdateLayerProp}
             oppdaterElement={what + ".vann_navn"}


### PR DESCRIPTION
- bakgrunnskart hadde ikke fungerende fargevelger, blant annet pga litt feilende logikk etter omplassering av elementer. Endret dem nå til å ha litt sub-bokser og inni-bokser med åpneknapp. Muligens ikke optimal løsning, men tenker good enough for nå.
- Fikset også at dobbelklikk i kart zoomet. det gir ikke mening når klikk trigger punktsetting og åpning av punkt. Da ble det rar adferd. Vil vi ha den tilbake må vi deaktivere tasteklikk for dobbelklikking.