### PR TITLE
favorite vs. current layer issues corrected

### DIFF
--- a/src/AppSettings/AppFunksjoner/oppdaterLagProperties.js
+++ b/src/AppSettings/AppFunksjoner/oppdaterLagProperties.js
@@ -40,9 +40,9 @@ export default function oppdaterLagProperties(
   // Nåværende kartlag ligger i state.meta
   let currentnode = parent.state.meta;
   if (elementType === "barn") {
-    currentnode = childElement(currentnode.barn, key, value, layer_input);
+    childElement(currentnode.barn, key, value, layer_input);
   } else {
-    currentnode = setValue(currentnode, key, value);
+    setValue(currentnode, key, value);
   }
 
   // Laget er et aktivt kartlag, og ligger derfor også i state.aktive

--- a/src/AppSettings/AppFunksjoner/oppdaterLagProperties.js
+++ b/src/AppSettings/AppFunksjoner/oppdaterLagProperties.js
@@ -37,19 +37,24 @@ export default function oppdaterLagProperties(
     layer = childLayer(layer);
   }
 
-  // Laget er et aktivt kartlag, og ligger derfor i state.aktive
-  const aktive = parent.state.aktiveLag;
-  let node = aktive[layer];
-
-  // Laget er nåværende kartlag, og ligger derfor i state.meta
-  if (!node) {
-    node = parent.state.meta;
-  }
-
+  // Nåværende kartlag ligger i state.meta
+  let currentnode = parent.state.meta;
   if (elementType === "barn") {
-    node = childElement(node.barn, key, value, layer_input);
+    currentnode = childElement(currentnode.barn, key, value, layer_input);
   } else {
-    node = setValue(node, key, value);
+    currentnode = setValue(currentnode, key, value);
   }
+
+  // Laget er et aktivt kartlag, og ligger derfor også i state.aktive
+  const aktive = parent.state.aktiveLag;
+  let favenode = aktive[layer];
+  if (favenode) {
+    if (elementType === "barn") {
+      favenode = childElement(favenode.barn, key, value, layer_input);
+    } else {
+      favenode = setValue(favenode, key, value);
+    }
+  }
+
   return aktive;
 }


### PR DESCRIPTION
fixes #1768

Aktive kartlag ble duplisert inn som en egen struktur.
Men endringer i interface ble bare sendt til étt lag, som ga mening slik applikasjonen var før. 
Nå derimot styres f.eks farger og opacity alltid fra current-element, så da må begge objekter targetes av oppdateringsfunksjonen, slik at de to alltid er i sync. Eneste ulempe er at har man tukla med et lag, kan man ikke få tak i orginalen uten å refreshe. Men det er kanskje greit?