### PR TITLE
Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: build and publish kommune
+name: build and publish
 
 on:
   push:
@@ -15,7 +15,6 @@ jobs:
         with:
           node-version: "18.x"
       - run: npm install --legacy-peer-deps
-      - run: npm update
       - run: npm run build
       - name: Check downloaded files
         run: ./.github/workflows/filecheck.sh


### PR DESCRIPTION
npm update tror jeg er overflødig fordi install på linja før allerede har installert "nyeste" godkjente versjoner.  https://docs.npmjs.com/cli/v6/commands/npm-update
